### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Built with [Electron] and [Moment.js].
 **[Download]**, unzip, and move `Timestamp.app` to the `/Applications` directory.
 
 ### Homebrew
-Simply run `brew cask install timestamp` in your terminal.
+Simply run `brew install --cask timestamp` in your terminal.
 
 ## Support
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524